### PR TITLE
fix slack link

### DIFF
--- a/content/community/slack.md
+++ b/content/community/slack.md
@@ -9,5 +9,5 @@ type: "social"
 ---
 
 The ArtemisCloud community has a Slack chatroom where you can listen in and ask questions. Stop by and say hello, but 
-keep in mind that basic rules of civility apply. Join us at [artemiscloudio.slack.com](artemiscloudio.slack.com)
+keep in mind that basic rules of civility apply. Join us at [artemiscloudio.slack.com](https://artemiscloudio.slack.com)
 


### PR DESCRIPTION
fix the slack community link to include the full URL. This is needed because by clicking on the current link it tries to load https://artemiscloud.github.io/website/community/artemiscloudio.slack.com